### PR TITLE
Update sbt-devoops and add sbt-devoops-starter

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-
-val sbtDevOopsVersion = "2.22.0"
+val sbtDevOopsVersion = "2.24.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % sbtDevOopsVersion)


### PR DESCRIPTION
Update `sbt-devoops` and add `sbt-devoops-starter`
- Updated `sbtDevOopsVersion` from `2.22.0` to `2.24.0`
- Add '`sbt-devoops-starter`' plugin